### PR TITLE
Cryptospam filter + too long message error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       run: npm run lint
     - name: run jest tests
       env:
-        BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+        DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
         GUILD_ID: ${{ secrets.GUILD_ID }}
         BOT_ID: ${{ secrets.BOT_ID }}
         PREFIX: ${{ secrets.PREFIX }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add `.env` file to root of the repository (same directory with `package.json`).
 Add following contents to `.env` file:
 ```
 PREFIX=!
-BOT_TOKEN=your-own-token
+DISCORD_BOT_TOKEN=your-own-token
 GUILD_ID=your-discord-server-id
 BOT_ID=id-of-your-bot
 CLIENT_SECRET=your-client-secret
@@ -43,7 +43,6 @@ POSTGRES_PASSWORD=your-postgres-password
 DB_HOST= (only if you are not using PostgreSQL locally)
 
 # Bridge
-DISCORD_BOT_TOKEN=discord-bridge-bot-token
 TELEGRAM_BOT_TOKEN=telegram-bridge-bot-token
 TG_BRIDGE_ENABLED=true
 ```

--- a/documentation/setupmainbot.md
+++ b/documentation/setupmainbot.md
@@ -27,7 +27,7 @@ Get your Bot token by clicking the "Copy" button.
 ![Bot token](./images/token.png)
 
 ```
-Add this token to `.env` file : BOT_TOKEN=your-own-token.
+Add this token to `.env` file : DISCORD_BOT_TOKEN=your-own-token.
 ```
 
 ## Connect your bot to your Discord server

--- a/src/bridge/service.js
+++ b/src/bridge/service.js
@@ -104,9 +104,9 @@ const handleBridgeMessage = async (message, courseName, Course) => {
 
   while (msg.includes('<@!')) {
     const userID = msg.match(/(?<=<@!).*?(?=>)/)[0];
-    let user = message.guild.members.cache.get(userID);
-    user ? user = user.user.username : user = "Jon Doe";
-    msg = msg.replace('<@!' + userID + '>', user);
+    let userName = message.guild.members.cache.get(userID);
+    userName ? userName = user.user.username : userName = "Jon Doe";
+    msg = msg.replace('<@!' + userID + '>', userName);
   }
 
   const media = message.attachments.first();

--- a/src/discordBot/index.js
+++ b/src/discordBot/index.js
@@ -3,7 +3,7 @@ const { Client, Intents } = require("discord.js");
 const fs = require("fs");
 const { Course } = require("../db/dbInit");
 
-const token = process.env.BOT_TOKEN;
+const token = process.env.DISCORD_BOT_TOKEN;
 const intents = [
   Intents.FLAGS.GUILDS,
   Intents.FLAGS.GUILD_MEMBERS,

--- a/src/discordBot/services/command.js
+++ b/src/discordBot/services/command.js
@@ -5,7 +5,7 @@ const { SlashCommandBuilder } = require("@discordjs/builders");
 const { Routes } = require("discord-api-types/v9");
 const clientId = process.env.BOT_ID;
 const guildId = process.env.GUILD_ID;
-const token = process.env.BOT_TOKEN;
+const token = process.env.DISCORD_BOT_TOKEN;
 const { findCoursesFromDb } = require("./service");
 
 const getCourseChoices = async (showPrivate, Course) => {

--- a/src/server/api/api.js
+++ b/src/server/api/api.js
@@ -5,7 +5,7 @@ const guildId = process.env.GUILD_ID;
 const DISCORD_API = `https://discord.com/api/v${version}/guilds/${guildId}`;
 
 const authorization_type = "Bot";
-const authorization_token = process.env.BOT_TOKEN;
+const authorization_token = process.env.DISCORD_BOT_TOKEN;
 
 const getChannels = async () => {
   const response = await fetch(`${DISCORD_API}/channels`, {


### PR DESCRIPTION
Cryptospam filter: 

Checks text message from telegram for keywords, if >= 3 keywords found, stops message from being bridged to Discord. Special case: If the sender of message has "bot" in the username, adds 2 points to keyword filter. If recognized as spam, sends message to console log

Reworked too long messages. Before fix, huge error message as bot tried to use Discord api for over 2000 characters long message. Now checks length and stops earlier and gives error to console