### PR TITLE
V13 stabilityfixes and improvements

### DIFF
--- a/src/bridge/service.js
+++ b/src/bridge/service.js
@@ -1,3 +1,4 @@
+const { sendErrorReportNoInteraction } = require("../discordBot/services/message");
 let discordClient;
 let telegramClient;
 const keywords = ["crypto", "krypto", "btc", "doge", "btc", "eth", "musk", "money", "$", "usd", "bitcoin", "muskx.co", "coin", "elonmusk", "prize", "еlonmusk", "btc"];
@@ -50,6 +51,24 @@ const sendMessageToDiscord = async (message, channel) => {
         username: message.user.username,
         avatarURL: message.user.avatarUrl,
         files: [message.content.photo.url],
+      });
+    }
+
+    if (message.content.audio) {
+      await webhook.send({
+        content: message.content.audio.caption,
+        username: message.user.username,
+        avatarURL: message.user.avatarUrl,
+        files: [message.content.audio.url],
+      });
+    }
+
+    if (message.content.video) {
+      await webhook.send({
+        content: message.content.video.caption,
+        username: message.user.username,
+        avatarURL: message.user.avatarUrl,
+        files: [message.content.video.url],
       });
     }
   }
@@ -116,22 +135,25 @@ const handleBridgeMessage = async (message, courseName, Course) => {
   while (msg.includes("<@!")) {
     const userID = msg.match(/(?<=<@!).*?(?=>)/)[0];
     let userName = message.guild.members.cache.get(userID);
-    userName ? userName = userName.user.name : userName = "Jon Doe";
+    userName ? userName = userName.user.username : userName = "Jon Doe";
     msg = msg.replace("<@!" + userID + ">", userName);
   }
 
   const media = message.attachments.first();
   const gif = message.embeds[0];
-
-
-  if (media) {
-    await sendMediaToTelegram(group.telegramId, msg, sender, channel, media);
+  try {
+    if (media) {
+      await sendMediaToTelegram(group.telegramId, msg, sender, channel, media);
+    }
+    else if (gif != undefined && gif.type != undefined && gif.type == "gifv") {
+      await sendAnimationToTelegram(group.telegramId, sender, channel, gif.video.url);
+    }
+    else {
+      await sendMessageToTelegram(group.telegramId, msg, sender, channel);
+    }
   }
-  else if (gif != undefined && gif.type != undefined && gif.type == "gifv") {
-    await sendAnimationToTelegram(group.telegramId, sender, channel, gif.video.url);
-  }
-  else {
-    await sendMessageToTelegram(group.telegramId, msg, sender, channel);
+  catch (error) {
+    return await sendErrorReportNoInteraction(group.telegramId, message.member, message.channel.name, discordClient, error.toString());
   }
 };
 
@@ -168,9 +190,14 @@ const validateContent = (content) => {
 const sendMessageToTelegram = async (telegramId, content, sender, channel) => {
   sender ? escapeChars(sender) : null;
   content = validateContent(content);
-  sender ?
-    await telegramClient.telegram.sendMessage(telegramId, `*${sender}*${channel}\n${content}`, { parse_mode: "MarkdownV2" }) :
-    await telegramClient.telegram.sendMessage(telegramId, `${content}`, { parse_mode: "MarkdownV2" });
+  try {
+    sender ?
+      await telegramClient.telegram.sendMessage(telegramId, `*${sender}*${channel}\n${content}`, { parse_mode: "MarkdownV2" }) :
+      await telegramClient.telegram.sendMessage(telegramId, `${content}`, { parse_mode: "MarkdownV2" });
+  }
+  catch (error) {
+    return error;
+  }
 };
 
 const sendMediaToTelegram = async (telegramId, info, sender, channel, media) => {
@@ -178,25 +205,38 @@ const sendMediaToTelegram = async (telegramId, info, sender, channel, media) => 
   info = validateContent(info);
   const url = media.url;
   const caption = `*${sender}*${channel} ${info}`;
-  if (media.contentType.includes("video")) {
-    await telegramClient.telegram.sendVideo(telegramId, { url }, { caption, parse_mode: "MarkdownV2" });
+  const filename = `${media.name}`;
+  try {
+    if (media.contentType.includes("video")) {
+      await telegramClient.telegram.sendVideo(telegramId, { url, filename: filename }, { caption, parse_mode: "MarkdownV2" });
+    }
+    else if (media.contentType.includes("audio")) {
+      await telegramClient.telegram.sendAudio(telegramId, { url, filename: filename }, { caption, parse_mode: "MarkdownV2" });
+    }
+    else if (media.contentType.includes("gif")) {
+      await telegramClient.telegram.sendAnimation(telegramId, { url }, { caption, parse_mode: "MarkdownV2" });
+    }
+    else if (media.contentType.includes("image")) {
+      await telegramClient.telegram.sendPhoto(telegramId, { url }, { caption, parse_mode: "MarkdownV2" });
+    }
+    else if (media.contentType.includes("application") || media.contentType.includes("text/plain")) {
+      await telegramClient.telegram.sendDocument(telegramId, { url, filename: filename }, { caption, parse_mode: "MarkdownV2" });
+    }
   }
-  else if (media.contentType.includes("audio")) {
-    await telegramClient.telegram.sendAudio(telegramId, { url }, { caption, parse_mode: "MarkdownV2" });
+  catch (error) {
+    return error;
   }
-  else if (media.contentType.includes("gif")) {
-    await telegramClient.telegram.sendAnimation(telegramId, { url }, { caption, parse_mode: "MarkdownV2" });
-  }
-  else if (media.contentType.includes("image") || media.contentType.includes("pdf")) {
-    await telegramClient.telegram.sendPhoto(telegramId, { url }, { caption, parse_mode: "MarkdownV2" });
-  }
-
 };
 
 const sendAnimationToTelegram = async (telegramId, sender, channel, url) => {
   sender = escapeChars(sender);
   const caption = `*${sender}*${channel}`;
-  await telegramClient.telegram.sendAnimation(telegramId, { url }, { caption, parse_mode: "MarkdownV2" });
+  try {
+    await telegramClient.telegram.sendAnimation(telegramId, { url }, { caption, parse_mode: "MarkdownV2" });
+  }
+  catch (error) {
+    return error;
+  }
 };
 
 const getCourseName = (categoryName) => {

--- a/src/discordBot/commands/admin/reloadCommands.js
+++ b/src/discordBot/commands/admin/reloadCommands.js
@@ -12,6 +12,6 @@ module.exports = {
   description: "Reload slash commands.",
   role: "admin",
   usage: "!reloadcommands",
-  args: true,
+  args: false,
   execute,
 };

--- a/src/discordBot/commands/admin/remove.js
+++ b/src/discordBot/commands/admin/remove.js
@@ -1,14 +1,21 @@
-const { updateGuide, findCategoryName, removeCourseFromDb } = require("../../services/service");
+const { updateGuide, findCategoryName, removeCourseFromDb, findCourseNickNameFromDbWithCourseCode } = require("../../services/service");
 const { courseAdminRole } = require("../../../../config.json");
 
 const execute = async (message, args, Course) => {
   if (message.member.permissions.has("ADMINISTRATOR")) {
-    const courseName = args[0];
-
+    let courseName = args.join(" ");
     const guild = message.guild;
 
-    const courseString = findCategoryName(courseName, guild);
-    const category = guild.channels.cache.find(c => c.type === "GUILD_CATEGORY" && c.name.toLowerCase() === courseString.toLowerCase());
+    let courseString = findCategoryName(courseName, guild);
+    let category = guild.channels.cache.find(c => c.type === "GUILD_CATEGORY" && c.name.toLowerCase() === courseString.toLowerCase());
+    if (!category) {
+      const courseNickName = await findCourseNickNameFromDbWithCourseCode(courseName, Course);
+      if (courseNickName) {
+        courseName = String(courseNickName.dataValues.name);
+        courseString = findCategoryName(courseName, guild);
+        category = guild.channels.cache.find(c => c.type === "GUILD_CATEGORY" && c.name.toLowerCase() === courseString.toLowerCase());
+      }
+    }
 
     if (!category) return message.reply(`Error: Invalid course name: ${courseName}.`);
     await Promise.all(guild.channels.cache

--- a/src/discordBot/services/message.js
+++ b/src/discordBot/services/message.js
@@ -14,6 +14,13 @@ const sendErrorReport = async (interaction, client, error) => {
   await commandsChannel.send({ content: error });
 };
 
+const sendErrorReportNoInteraction = async (telegramId, member, channel, client, error) => {
+  const commandsChannel = client.guild.channels.cache.find((c) => validateChannel(c));
+  const msg = `**ERROR DETECTED!**\nMember: ${member}\nChannel: ${channel}`;
+  await commandsChannel.send({ content: msg });
+  await commandsChannel.send({ content: error });
+};
+
 const sendErrorEphemeral = async (interaction, msg) => {
   await interaction.reply({ content: `Error: ${msg}`, ephemeral: true });
 };
@@ -33,6 +40,7 @@ const editErrorEphemeral = async (interaction, msg) => {
 module.exports = {
   sendErrorReport,
   sendErrorEphemeral,
+  sendErrorReportNoInteraction,
   sendEphemeral,
   editEphemeral,
   editErrorEphemeral,

--- a/src/discordBot/services/service.js
+++ b/src/discordBot/services/service.js
@@ -311,6 +311,14 @@ const findCourseFromDbWithFullName = async (courseFullName, Course) => {
   });
 };
 
+const findCourseNickNameFromDbWithCourseCode = async (courseName, Course) => {
+  return await Course.findOne({
+    where: {
+      code: { [Sequelize.Op.iLike]: courseName },
+    },
+  });
+};
+
 
 module.exports = {
   createCategoryName,
@@ -341,4 +349,5 @@ module.exports = {
   findCourseFromDb,
   findCourseFromDbWithFullName,
   findCoursesFromDb,
+  findCourseNickNameFromDbWithCourseCode,
 };

--- a/src/telegramBot/events/audio.js
+++ b/src/telegramBot/events/audio.js
@@ -1,0 +1,24 @@
+const { createDiscordUser, validDiscordChannel, sendMessageToDiscord } = require("../../bridge/service");
+
+const execute = async (ctx, message, telegramClient, Course) => {
+  const id = ctx.message.chat.id;
+  const group = await Course.findOne({ where: { telegramId: String(id) } });
+  if (!group) {
+    return;
+  }
+  const url = await telegramClient.telegram.getFileLink(ctx.message.audio.file_id);
+  const courseName = group.name;
+  if (String(ctx.message.chat.id) === group.telegramId) {
+    const discordUser = await createDiscordUser(ctx);
+    const channel = await validDiscordChannel(courseName);
+    if (!channel) return;
+    const msg = { user: discordUser, content: { audio: { url: url.href, caption: ctx.message.caption } } };
+    return await sendMessageToDiscord(msg, channel);
+  }
+};
+
+
+module.exports = {
+  name: "audio",
+  execute,
+};

--- a/src/telegramBot/events/text.js
+++ b/src/telegramBot/events/text.js
@@ -24,7 +24,7 @@ const execute = async (ctx, message, telegramClient, Course) => {
     const databaseValue = await Course.findOne({ where: { name: discordCourseName } }).catch((error) => console.log(error));
     if (databaseValue.telegramId) {
       return await sendMessageToTelegram(id,
-        `Bridge not created: this course ${group.name} has bridge already`);
+        `Bridge not created: this course ${discordCourseName} has bridge already`);
     }
     databaseValue.telegramId = String(id);
     await databaseValue.save();

--- a/src/telegramBot/events/video.js
+++ b/src/telegramBot/events/video.js
@@ -1,0 +1,24 @@
+const { createDiscordUser, validDiscordChannel, sendMessageToDiscord } = require("../../bridge/service");
+
+const execute = async (ctx, message, telegramClient, Course) => {
+  const id = ctx.message.chat.id;
+  const group = await Course.findOne({ where: { telegramId: String(id) } });
+  if (!group) {
+    return;
+  }
+  const url = await telegramClient.telegram.getFileLink(ctx.message.video.file_id);
+  const courseName = group.name;
+  if (String(ctx.message.chat.id) === group.telegramId) {
+    const discordUser = await createDiscordUser(ctx);
+    const channel = await validDiscordChannel(courseName);
+    if (!channel) return;
+    const msg = { user: discordUser, content: { video: { url: url.href, caption: ctx.message.caption } } };
+    return await sendMessageToDiscord(msg, channel);
+  }
+};
+
+
+module.exports = {
+  name: "video",
+  execute,
+};


### PR DESCRIPTION
Stability fixes and improvements for v13 launch:

**Bridge creation**
- When trying to bridge tg to discord channel that already has been linked, error message actually crashed bot, now fixed and error message works

**!remove [channel]**
- channels that have space in the nickname can now be removed properly
- remove channel now supports courseCode as parameter
- now tries to use parameter first as course nickname, if not found, then uses it as courseCode and tries to find corresponding course nickname and tries again

**!reloadCommands**
- Now actually works (changed argument flag to false so now doesn't fail as there are no parameters to use)

**Discord -> Telegram bridge, broken bridge**
- in the case of altering tg group from private to public (changes tg chat id) now sends error message to commands channel that states that channel uses old chat id

**Discord -> Telegram, @nick mentions**
- telegram now shows nicknames properly e.g. @EgoTastic mention on discord shows as EgoTastic in telegram

**Telegram -> Discord Media**
- bridge now supports audio and video to be sent from to to discord

**Discord -> Telegram bridge Documents**
- documents now supported, pdf, office files, txt/js/exe files tested
- attachment names now show in telegram, rather than generic e.g. audio.mp3
